### PR TITLE
Add ollama support in MCP server

### DIFF
--- a/src/SemanticKernel.Agents.DatabaseAgent.MCPServer/Configuration/OllamaConfig.cs
+++ b/src/SemanticKernel.Agents.DatabaseAgent.MCPServer/Configuration/OllamaConfig.cs
@@ -1,0 +1,10 @@
+﻿
+
+namespace SemanticKernel.Agents.DatabaseAgent.MCPServer.Configuration;
+
+internal class OllamaConfig
+{
+    public string ModelId { get; set; }
+
+    public string Endpoint { get; set; }
+}

--- a/src/SemanticKernel.Agents.DatabaseAgent.MCPServer/Extensions/IKernelBuilderExtension.cs
+++ b/src/SemanticKernel.Agents.DatabaseAgent.MCPServer/Extensions/IKernelBuilderExtension.cs
@@ -13,13 +13,21 @@ namespace SemanticKernel.Agents.DatabaseAgent.MCPServer.Extensions
             switch (service["Type"])
             {
                 case "AzureOpenAI":
-                    var config = service.Get<AzureOpenAIConfig>();
-                    return builder.AddAzureOpenAIChatCompletion(config.Deployment, config.Endpoint, config.APIKey);
+                    var azureConfig = service.Get<AzureOpenAIConfig>();
+                    return builder.AddAzureOpenAIChatCompletion(azureConfig.Deployment, azureConfig.Endpoint, azureConfig.APIKey);
+#pragma warning disable SKEXP0070 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+                case "Ollama":
+                    var ollamaConfig = service.Get<OllamaConfig>();
+                    return builder.AddOllamaChatCompletion(ollamaConfig.ModelId, new Uri(ollamaConfig.Endpoint), null);
+#pragma warning restore SKEXP0070 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
                 default:
                     throw new ArgumentException($"Unknown service type: '{service["Type"]}' for {serviceName}");
             }
 
         }
+#pragma warning disable SKEXP0010 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable SKEXP0070 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
         internal static IKernelBuilder AddTextEmbeddingFromConfiguration(this IKernelBuilder builder, IConfiguration configuration, string serviceName)
         {
@@ -28,14 +36,18 @@ namespace SemanticKernel.Agents.DatabaseAgent.MCPServer.Extensions
             switch (service["Type"])
             {
                 case "AzureOpenAI":
-                    var config = service.Get<AzureOpenAIConfig>();
+                    var azureConfig = service.Get<AzureOpenAIConfig>();
 
-#pragma warning disable SKEXP0010 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-                    return builder.AddAzureOpenAITextEmbeddingGeneration(config.Deployment, config.Endpoint, config.APIKey);
-#pragma warning restore SKEXP0010 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+                    return builder.AddAzureOpenAITextEmbeddingGeneration(azureConfig.Deployment, azureConfig.Endpoint, azureConfig.APIKey);
+                case "Ollama":
+                    var ollamaConfig = service.Get<OllamaConfig>();
+                    return builder.AddOllamaTextEmbeddingGeneration(ollamaConfig.ModelId, new Uri(ollamaConfig.Endpoint), null);
                 default:
                     throw new ArgumentException("Unknown service type");
             }
         }
+#pragma warning restore SKEXP0070 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning restore SKEXP0010 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
     }
 }

--- a/src/SemanticKernel.Agents.DatabaseAgent.MCPServer/SemanticKernel.Agents.DatabaseAgent.MCPServer.csproj
+++ b/src/SemanticKernel.Agents.DatabaseAgent.MCPServer/SemanticKernel.Agents.DatabaseAgent.MCPServer.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="9.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.3" />
     <PackageReference Include="Microsoft.SemanticKernel.Connectors.InMemory" Version="1.44.0-preview" />
+    <PackageReference Include="Microsoft.SemanticKernel.Connectors.Ollama" Version="1.44.0-alpha" />
     <PackageReference Include="Microsoft.SemanticKernel.Connectors.Qdrant" Version="1.44.0-preview" />
     <PackageReference Include="Microsoft.SemanticKernel.Connectors.Sqlite" Version="1.44.0-preview" />
     <PackageReference Include="ModelContextProtocol" Version="0.1.0-preview.1.25171.12" />


### PR DESCRIPTION
## Description

What's new?

- Add ollama support in MCP server.

You can now configure the MCP server by using OLLAMA endpoint in configuration: 

```
--services:codestral:Endpoint="Your-ollama-server-endpoint" --services:codestral:ModelId=codestral:latest
```

## What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other