### PR TITLE
Fix hardcoded vector size.

### DIFF
--- a/src/SemanticKernel.Agents.DatabaseAgent/TableDefinitionSnippet.cs
+++ b/src/SemanticKernel.Agents.DatabaseAgent/TableDefinitionSnippet.cs
@@ -16,7 +16,7 @@ namespace SemanticKernel.Agents.DatabaseAgent
         [VectorStoreRecordData]
         public string? Description { get; set; }
 
-        [VectorStoreRecordVector(1536)]
+        [VectorStoreRecordVector]
         public ReadOnlyMemory<float> TextEmbedding { get; set; }
     }
 }


### PR DESCRIPTION
## Description

What's new?

- When using Ollama models the vector's size should be adjusted. This remove the hardcoded value for the vector dimension.

## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other