### PR TITLE
(ci): update ci to use nomic-embed-text:v1.5 embedding model in Ollama

### DIFF
--- a/.github/workflows/execute_test_for_model.yml
+++ b/.github/workflows/execute_test_for_model.yml
@@ -88,4 +88,4 @@ jobs:
           ## Nomic Embedding Models via Ollama
           SERVICES__NOMICEMBEDTEXT__TYPE: Ollama
           SERVICES__NOMICEMBEDTEXT__ENDPOINT: ${{ secrets.OLLAMA_ENDPOINT }}
-          SERVICES__NOMICEMBEDTEXT__MODELID: nomic-embed-text:latest
+          SERVICES__NOMICEMBEDTEXT__MODELID: nomic-embed-text:v1.5


### PR DESCRIPTION
## Description

What's new?

- Fix CI to use nomic-embed-text:v1.5 in Ollama contexts

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other