### PR TITLE
(chore): rerank with BM25 related tables to increase reliability

### DIFF
--- a/src/SemanticKernel.Agents.DatabaseAgent.MCPServer/SemanticKernel.Agents.DatabaseAgent.MCPServer.csproj
+++ b/src/SemanticKernel.Agents.DatabaseAgent.MCPServer/SemanticKernel.Agents.DatabaseAgent.MCPServer.csproj
@@ -44,6 +44,7 @@
     <PackageReference Include="MySql.Data" Version="9.4.0" />
     <PackageReference Include="Npgsql" Version="9.0.3" />
     <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="23.9.1" />
+    <PackageReference Include="SemanticKernel.Reranker.BM25" Version="1.0.1-beta03" />
     <PackageReference Include="System.Data.Odbc" Version="9.0.8" />
     <PackageReference Include="System.Data.OleDb" Version="9.0.8" />
     <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="9.0.8" />

--- a/src/SemanticKernel.Agents.DatabaseAgent/DatabaseAgentFactory.cs
+++ b/src/SemanticKernel.Agents.DatabaseAgent/DatabaseAgentFactory.cs
@@ -237,7 +237,7 @@ public static class DatabaseAgentFactory
             {
                 { "prompt", "List all tables" },
                 { "previousAttempt", previousSQLQuery },
-                { "previousException", e },
+                { "previousException", e?.Message },
             })
             .ConfigureAwait(false);
 
@@ -269,7 +269,7 @@ public static class DatabaseAgentFactory
             promptTemplate: promptProvider.ReadPrompt(AgentPromptConstants.ExtractTableName),
             templateFormat: "handlebars",
             promptTemplateFactory: new HandlebarsPromptTemplateFactory(),
-            executionSettings: PromptExecutionSettingsHelper.GetPromptExecutionSettings<ExtractTableNameResponse>(), 
+            executionSettings: PromptExecutionSettingsHelper.GetPromptExecutionSettings<ExtractTableNameResponse>(),
             functionName: AgentPromptConstants.ExtractTableName);
         var tableDescriptionGenerator = KernelFunctionFactory.CreateFromPrompt(
             promptTemplate: promptProvider.ReadPrompt(AgentPromptConstants.ExplainTable),
@@ -303,8 +303,8 @@ public static class DatabaseAgentFactory
 
 
                  var response = JsonSerializer.Deserialize<ExtractTableNameResponse>(tableNameResponse.GetValue<string>()!);
-                 
-                 if(response is null || string.IsNullOrWhiteSpace(response.TableName))
+
+                 if (response is null || string.IsNullOrWhiteSpace(response.TableName))
                  {
                      throw new InvalidOperationException("Failed to extract table name from the item.");
                  }
@@ -365,7 +365,7 @@ public static class DatabaseAgentFactory
                 {
                     { "prompt", $"Extract the structure of table {tableName} by listing the column attributes, including the column name, data type, maximum length, and default value." },
                     { "previousAttempt", previousSQLQuery },
-                    { "previousException", e },
+                    { "previousException", e?.Message },
                 }, cancellationToken)
                 .ConfigureAwait(false);
 
@@ -387,7 +387,7 @@ public static class DatabaseAgentFactory
                     { "prompt", $"Get the first 5 rows for '{tableName}'" },
                     { "tablesDefinition", tableDefinition },
                     { "previousAttempt", previousSQLQuery },
-                    { "previousException", e },
+                    { "previousException", e?.Message },
                 }, cancellationToken)
                     .ConfigureAwait(false);
 

--- a/src/SemanticKernel.Agents.DatabaseAgent/DatabasePluginOptions.cs
+++ b/src/SemanticKernel.Agents.DatabaseAgent/DatabasePluginOptions.cs
@@ -9,6 +9,4 @@ public sealed class DatabasePluginOptions
     public double? Temperature { get; set; } = .1E-9;
 
     public double? TopP { get; set; } = .1E-9;
-
-    public double? MinScore { get; set; } = 0.5;
 }

--- a/src/SemanticKernel.Agents.DatabaseAgent/Prompts/WriteSQLQuery.md
+++ b/src/SemanticKernel.Agents.DatabaseAgent/Prompts/WriteSQLQuery.md
@@ -416,7 +416,7 @@ Below is the SQL query you generated:
 ```
 The error was: 
 ```
-{{ previousException.Message }}
+{{ previousException }}
 ```
 
 To enhance the new query generation, please analyze the previous attempt and consider the following:

--- a/src/SemanticKernel.Agents.DatabaseAgent/SemanticKernel.Agents.DatabaseAgent.csproj
+++ b/src/SemanticKernel.Agents.DatabaseAgent/SemanticKernel.Agents.DatabaseAgent.csproj
@@ -41,6 +41,7 @@
     <PackageReference Include="Microsoft.SemanticKernel.Connectors.AzureOpenAI" Version="1.64.0" />
     <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.64.0" />
     <PackageReference Include="Microsoft.SemanticKernel.PromptTemplates.Handlebars" Version="1.64.0" />
+    <PackageReference Include="SemanticKernel.Reranker.BM25" Version="1.0.1-beta03" />
     <PackageReference Include="Validation" Version="2.6.68" />
   </ItemGroup>
 


### PR DESCRIPTION
## Description

What's new?

- Add BM25 reranking in related tables (after semantic search)
- remove min-score, use only the topK parameter to filter related tables

## What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other